### PR TITLE
Unified status object to match a certain pattern

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,11 +93,7 @@ module.exports = (loglevel) => {
 
     if (SLAVE_ENABLED) {
       try {
-        const rawSlaveData = await controller.slave.getData();
-        slaveData = {
-          temp: rawSlaveData.data.temp,
-          hum: rawSlaveData.data.hum,
-        };
+        slaveData = await controller.slave.getData();
       } catch (err) {
         log.error({ err }, 'Error getting slave data');
       }
@@ -119,7 +115,7 @@ module.exports = (loglevel) => {
         slaveData,
         temp,
       );
-      desiredTemp = desiredObj.desired;
+      desiredTemp = desiredObj.temp;
     } catch (err) {
       log.error({ err }, 'Error getting temperatures');
       log.info('Disable heating');

--- a/controller/calendar.controller.js
+++ b/controller/calendar.controller.js
@@ -82,7 +82,7 @@ module.exports = (log, cache) => {
     const event = await getCurrentEvent(auth);
     if (!event) {
       return {
-        desired: MIN_TEMP,
+        temp: MIN_TEMP,
         master: 100,
         slave: 0,
       };
@@ -93,7 +93,7 @@ module.exports = (log, cache) => {
       const prioArray = event.summary.split(';');
       if (prioArray.length === 3) {
         desiredObj = {
-          desired: parseFloat(prioArray[0]),
+          temp: parseFloat(prioArray[0]),
           master: parseFloat(prioArray[1]),
           slave: parseFloat(prioArray[2]),
         };
@@ -102,34 +102,34 @@ module.exports = (log, cache) => {
         if (prioSum !== 100) {
           log.warn({ prioSum }, 'The sum does not equal 100%, falling back to 100%');
           desiredObj = {
-            desired: parseFloat(prioArray[0]),
+            temp: parseFloat(prioArray[0]),
             master: 100,
             slave: 0,
           };
         }
       } else {
         desiredObj = {
-          desired: parseFloat(event.summary),
+          temp: parseFloat(event.summary),
           master: 100,
           slave: 0,
         };
       }
 
-      assert.isNotNaN(desiredObj.desired);
+      assert.isNotNaN(desiredObj.temp);
       assert.isNotNaN(desiredObj.master);
       assert.isNotNaN(desiredObj.slave);
     } catch (e) {
       log.error({ e }, 'Unable to parse, fallback to MIN_TEMP');
       desiredObj = {
-        desired: MIN_TEMP,
+        temp: MIN_TEMP,
         master: 100,
         slave: 0,
       };
     }
 
-    if (desiredObj.desired > MAX_TEMP) {
+    if (desiredObj.temp > MAX_TEMP) {
       desiredObj = {
-        desired: MAX_TEMP,
+        temp: MAX_TEMP,
         master: 100,
         slave: 0,
       };

--- a/controller/database.controller.js
+++ b/controller/database.controller.js
@@ -75,7 +75,7 @@ module.exports = async (log, cache) => {
 
     const returnObject = {
       updated: time,
-      value,
+      temp: value,
     };
 
     await cache.updateMqttData(returnObject);

--- a/controller/slave.controller.js
+++ b/controller/slave.controller.js
@@ -1,4 +1,5 @@
 const request = require('request');
+const { assert } = require('chai');
 
 module.exports = (log, cache) => {
   const getData = async () => new Promise((resolve, reject) => {
@@ -13,8 +14,13 @@ module.exports = (log, cache) => {
       log.trace({ body }, 'Slavedata');
       try {
         const jsonData = JSON.parse(body);
-        await cache.updateSlaveData(jsonData);
-        return resolve(jsonData);
+
+        assert.isTrue(jsonData.success);
+        assert.isDefined(jsonData.data);
+        assert.isNumber(jsonData.data.temp);
+
+        await cache.updateSlaveData(jsonData.data);
+        return resolve(jsonData.data);
       } catch (err) {
         return reject(err);
       }

--- a/routes/v1/status.route.js
+++ b/routes/v1/status.route.js
@@ -11,40 +11,37 @@ const rateLimiterStatus = new RateLimit({
 
 module.exports = (log, controller) => {
   const getStatusObject = async () => {
-    const returnObj = {};
+    const returnObj = {
+      master: {},
+    };
 
     try {
-      const slaveData = await controller.cache.getSlaveData();
-      returnObj.slave = {
-        currentTemp: slaveData.data.temp,
-        currentHum: slaveData.data.hum,
-      };
+      returnObj.slave = await controller.cache.getSlaveData();
     } catch (err) {
       log.error({ err }, 'Error getting slave data');
     }
 
     try {
-      const mqttData = await controller.cache.getMqttData();
-      returnObj.mqtt = mqttData;
+      returnObj.mqtt = await controller.cache.getMqttData();
     } catch (err) {
       log.error({ err }, 'Error getting mqtt data');
     }
 
     try {
-      const relayData = await controller.cache.getRelayState();
-      returnObj.heating = relayData === 1;
-    } catch (err) {
-      log.error({ err }, 'Error getting relay data');
-    }
-
-    try {
-      returnObj.desiredTemp = await controller.cache.getDesiredObject();
+      returnObj.desired = await controller.cache.getDesiredObject();
     } catch (err) {
       log.error({ err }, 'Error getting calendar data');
     }
 
     try {
-      returnObj.currentTemp = await controller.cache.getCurrentTemperature();
+      const relayData = await controller.cache.getRelayState();
+      returnObj.master.heating = relayData === 1;
+    } catch (err) {
+      log.error({ err }, 'Error getting relay data');
+    }
+
+    try {
+      returnObj.master.temp = await controller.cache.getCurrentTemperature();
     } catch (err) {
       log.error({ err }, 'Error getting temperature data');
     }

--- a/test/controller/calendar.controller.test.js
+++ b/test/controller/calendar.controller.test.js
@@ -59,7 +59,7 @@ describe('Calendar Controller', () => {
     const desiredObj = await CC(log, CacheController)
       .getDesiredObject();
 
-    expect(desiredObj.desired).to.equal(18.4);
+    expect(desiredObj.temp).to.equal(18.4);
     expect(desiredObj.master).to.equal(100);
     expect(desiredObj.slave).to.equal(0);
     assert.isTrue(authorizeSpy.called);
@@ -96,7 +96,7 @@ describe('Calendar Controller', () => {
     const desiredObj = await CC(log, CacheController)
       .getDesiredObject();
 
-    expect(desiredObj.desired).to.equal(18.4);
+    expect(desiredObj.temp).to.equal(18.4);
     expect(desiredObj.master).to.equal(95);
     expect(desiredObj.slave).to.equal(5);
     assert.isTrue(authorizeSpy.called);
@@ -123,7 +123,7 @@ describe('Calendar Controller', () => {
     const desiredObj = await CC(log, CacheController)
       .getDesiredObject();
 
-    expect(desiredObj.desired).to.equal(15);
+    expect(desiredObj.temp).to.equal(15);
     expect(desiredObj.master).to.equal(100);
     expect(desiredObj.slave).to.equal(0);
     assert.isTrue(authorizeSpy.called);
@@ -160,7 +160,7 @@ describe('Calendar Controller', () => {
     const desiredObj = await CC(log, CacheController)
       .getDesiredObject();
 
-    expect(desiredObj.desired).to.equal(15);
+    expect(desiredObj.temp).to.equal(15);
     expect(desiredObj.master).to.equal(100);
     expect(desiredObj.slave).to.equal(0);
     assert.isTrue(authorizeSpy.called);
@@ -197,7 +197,7 @@ describe('Calendar Controller', () => {
     const desiredObj = await CC(log, CacheController)
       .getDesiredObject();
 
-    expect(desiredObj.desired).to.equal(15);
+    expect(desiredObj.temp).to.equal(15);
     expect(desiredObj.master).to.equal(100);
     expect(desiredObj.slave).to.equal(0);
     assert.isTrue(authorizeSpy.called);
@@ -234,7 +234,7 @@ describe('Calendar Controller', () => {
     const desiredObj = await CC(log, CacheController)
       .getDesiredObject();
 
-    expect(desiredObj.desired).to.equal(18.4);
+    expect(desiredObj.temp).to.equal(18.4);
     expect(desiredObj.master).to.equal(100);
     expect(desiredObj.slave).to.equal(0);
     assert.isTrue(authorizeSpy.called);
@@ -271,7 +271,7 @@ describe('Calendar Controller', () => {
     const desiredObj = await CC(log, CacheController)
       .getDesiredObject();
 
-    expect(desiredObj.desired).to.equal(27);
+    expect(desiredObj.temp).to.equal(27);
     expect(desiredObj.master).to.equal(100);
     expect(desiredObj.slave).to.equal(0);
     assert.isTrue(authorizeSpy.called);

--- a/test/controller/database.controller.test.js
+++ b/test/controller/database.controller.test.js
@@ -132,7 +132,7 @@ describe('Database Controller', () => {
 
     const latestEntry = await instance.getLatestMqttEntry();
     expect(latestEntry.updated).to.eq(1550586338221);
-    expect(latestEntry.value).to.eq(12.5);
+    expect(latestEntry.temp).to.eq(12.5);
   });
 
   it('should fail to get latest mqtt entry', async () => {

--- a/test/controller/slave.controller.test.js
+++ b/test/controller/slave.controller.test.js
@@ -44,7 +44,8 @@ describe('Slave Controller', () => {
 
     const slaveData = await SC(log, CacheController).getData();
 
-    expect(slaveData).to.deep.equal(mockedSlaveResponse);
+    expect(slaveData.temp).to.eq(mockedSlaveResponse.data.temp);
+    expect(slaveData.hum).to.eq(mockedSlaveResponse.data.hum);
   });
 
   it('should fail [wrong host]', async () => {

--- a/test/routes/status.route.test.js
+++ b/test/routes/status.route.test.js
@@ -138,19 +138,28 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { master } = data;
+    const { desired } = data;
     const { slave } = data;
     const { mqtt } = data;
 
+    console.log(body);
     assert.isTrue(body.success);
-    expect(data.desiredTemp.desired).to.eq(25.4);
-    expect(data.desiredTemp.master).to.eq(100);
-    expect(data.desiredTemp.slave).to.eq(0);
-    expect(data.currentTemp).to.eq(21);
+
+    assert.isDefined(master);
     // Desired temp is 25.4, mocked ds18b20 returns 21 -> heating on
-    assert.isTrue(data.heating);
+    assert.isTrue(master.heating);
+    expect(master.temp).to.eq(21);
+
+    assert.isDefined(desired);
+    expect(desired.temp).to.eq(25.4);
+    expect(desired.master).to.eq(100);
+    expect(desired.slave).to.eq(0);
+
     assert.isDefined(slave);
-    expect(slave.currentTemp).to.equal(mockedSlaveData.data.temp);
-    expect(slave.currentHum).to.equal(mockedSlaveData.data.hum);
+    expect(slave.temp).to.equal(mockedSlaveData.data.temp);
+    expect(slave.hum).to.equal(mockedSlaveData.data.hum);
+
     assert.isDefined(mqtt);
     expect(mqtt.updated).to.equal(1550586338221);
     expect(mqtt.value).to.equal(12.5);
@@ -207,19 +216,26 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { desired } = data;
+    const { master } = data;
     const { slave } = data;
 
     assert.isTrue(body.success);
-    expect(data.desiredTemp.desired).to.eq(20.4);
-    expect(data.desiredTemp.master).to.eq(0);
-    expect(data.desiredTemp.slave).to.eq(100);
-    expect(data.currentTemp).to.eq(21);
+
+    assert.isDefined(master);
     // Desired temp is 20.4, master temperature is high enough (21), but master has 0% priority,
     // so only the slave temperature is getting into account and heating should be on
-    assert.isTrue(data.heating);
+    assert.isTrue(master.heating);
+    expect(master.temp).to.eq(21);
+
+    assert.isDefined(desired);
+    expect(desired.temp).to.eq(20.4);
+    expect(desired.master).to.eq(0);
+    expect(desired.slave).to.eq(100);
+
     assert.isDefined(slave);
-    expect(slave.currentTemp).to.equal(mockedSlaveData.data.temp);
-    expect(slave.currentHum).to.equal(mockedSlaveData.data.hum);
+    expect(slave.temp).to.equal(mockedSlaveData.data.temp);
+    expect(slave.hum).to.equal(mockedSlaveData.data.hum);
   });
 
   it('should get status [no slave]', async () => {
@@ -266,15 +282,22 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { desired } = data;
+    const { master } = data;
     const { slave } = data;
 
     assert.isTrue(body.success);
-    expect(data.desiredTemp.desired).to.eq(25.4);
-    expect(data.desiredTemp.master).to.eq(100);
-    expect(data.desiredTemp.slave).to.eq(0);
-    expect(data.currentTemp).to.eq(21);
+
+    assert.isDefined(master);
     // Desired temp is 25.4, mocked ds18b20 returns 21 -> heating on
-    assert.isTrue(data.heating);
+    assert.isTrue(master.heating);
+    expect(master.temp).to.eq(21);
+
+    assert.isDefined(desired);
+    expect(desired.temp).to.eq(25.4);
+    expect(desired.master).to.eq(100);
+    expect(desired.slave).to.eq(0);
+
     assert.isUndefined(slave);
   });
 
@@ -322,16 +345,110 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { desired } = data;
+    const { master } = data;
     const { slave } = data;
 
     assert.isTrue(body.success);
-    expect(data.desiredTemp.desired).to.eq(25.4);
-    expect(data.desiredTemp.master).to.eq(50);
-    expect(data.desiredTemp.slave).to.eq(50);
-    expect(data.currentTemp).to.eq(21);
+
+    assert.isDefined(master);
     // Desired temp is 25.4, mocked ds18b20 returns 21 -> heating on
-    assert.isTrue(data.heating);
+    assert.isTrue(master.heating);
+    expect(master.temp).to.eq(21);
+
+    assert.isDefined(desired);
+    expect(desired.temp).to.eq(25.4);
+    expect(desired.master).to.eq(50);
+    expect(desired.slave).to.eq(50);
+
     assert.isUndefined(slave);
+  });
+
+  it('should get status [invalid mqtt value]', async () => {
+    const mockedSlaveData = {
+      success: true,
+      data: {
+        temp: 12.5,
+        hum: 32,
+      },
+    };
+    // Mock slave
+    nock('http://mocked.tempea.com:80')
+      .get('/mocked')
+      .reply(200, mockedSlaveData);
+
+    // Mock calendar
+    nock('https://www.googleapis.com:443')
+      .get(new RegExp('/calendar/v3/calendars/tempea-mocked/events/*'))
+      .reply(200, {
+        items: [
+          {
+            summary: '25.4',
+            start: {
+              dateTime: moment().subtract(1, 'days').valueOf(),
+            },
+            end: {
+              dateTime: moment().add(1, 'days').valueOf(),
+            },
+          },
+        ],
+      });
+
+    // Mock influx
+    nock('http://influx:8086')
+      .get(/.*/g)
+      .reply(200, {
+        results: [
+          {
+            statement_id: 0,
+            invalid: [],
+          },
+        ],
+      });
+
+    const authorizeSpy = sinon.spy();
+
+    const CC = proxyquire('../../controller/calendar.controller', {
+      'google-auth-library': {
+        JWT: function JWT() {
+          this.authorize = authorizeSpy;
+          this.request = async opts => request(opts);
+        },
+      },
+    });
+
+    controller.calendar = await CC(log, controller.cache);
+
+    // Run the job
+    await app.forceJob();
+
+    assert.isTrue(authorizeSpy.called);
+
+    const response = await chai.request(expressApp).get('/v1/status');
+    const { body } = response;
+    const { data } = body;
+    const { master } = data;
+    const { desired } = data;
+    const { slave } = data;
+    const { mqtt } = data;
+
+    assert.isTrue(body.success);
+
+    assert.isDefined(master);
+    // Desired temp is 25.4, mocked ds18b20 returns 21 -> heating on
+    assert.isTrue(master.heating);
+    expect(master.temp).to.eq(21);
+
+    assert.isDefined(desired);
+    expect(desired.temp).to.eq(25.4);
+    expect(desired.master).to.eq(100);
+    expect(desired.slave).to.eq(0);
+
+    assert.isDefined(slave);
+    expect(slave.temp).to.equal(mockedSlaveData.data.temp);
+    expect(slave.hum).to.equal(mockedSlaveData.data.hum);
+
+    assert.isUndefined(mqtt);
   });
 
   it('should get status [error in temperatures]', async () => {
@@ -401,18 +518,20 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { desired } = data;
+    const { master } = data;
     const { slave } = data;
 
     assert.isTrue(body.success);
     // The job returns if one or more temperatures are not available and turns of heating
-    assert.isUndefined(data.desiredTemp);
-    assert.isUndefined(data.currentTemp);
+    assert.isUndefined(desired);
+    assert.isUndefined(master.temp);
     // Heating has to be disabled on unknown temperatures
-    assert.isFalse(data.heating);
+    assert.isFalse(master.heating);
     // The slave should work as expected
     assert.isDefined(slave);
-    expect(slave.currentTemp).to.equal(mockedSlaveData.data.temp);
-    expect(slave.currentHum).to.equal(mockedSlaveData.data.hum);
+    expect(slave.temp).to.equal(mockedSlaveData.data.temp);
+    expect(slave.hum).to.equal(mockedSlaveData.data.hum);
 
     stubDesired.restore();
     stubRead.restore();
@@ -484,18 +603,20 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { desired } = data;
+    const { master } = data;
     const { slave } = data;
 
     assert.isTrue(body.success);
     // The job returns if one or more temperatures are not available and turns of heating
-    assert.isUndefined(data.desiredTemp);
-    assert.isUndefined(data.currentTemp);
+    assert.isUndefined(desired);
+    assert.isUndefined(master.temp);
     // Heating should be false, but setting the relay fails, so cache never gets set
-    assert.isUndefined(data.heating);
+    assert.isUndefined(master.heating);
     // The slave should work as expected
     assert.isDefined(slave);
-    expect(slave.currentTemp).to.equal(mockedSlaveData.data.temp);
-    expect(slave.currentHum).to.equal(mockedSlaveData.data.hum);
+    expect(slave.temp).to.equal(mockedSlaveData.data.temp);
+    expect(slave.hum).to.equal(mockedSlaveData.data.hum);
 
     stubRead.restore();
     stubWrite.restore();
@@ -565,17 +686,19 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { desired } = data;
+    const { master } = data;
     const { slave } = data;
 
     assert.isTrue(body.success);
-    expect(data.desiredTemp.desired).to.eq(25.4);
-    expect(data.currentTemp).to.eq(21);
+    expect(desired.temp).to.eq(25.4);
+    expect(master.temp).to.eq(21);
     // Heating should be true, but setting the relay fails, so cache never gets set
-    assert.isUndefined(data.heating);
+    assert.isUndefined(master.heating);
     // The slave should work as expected
     assert.isDefined(slave);
-    expect(slave.currentTemp).to.equal(mockedSlaveData.data.temp);
-    expect(slave.currentHum).to.equal(mockedSlaveData.data.hum);
+    expect(slave.temp).to.equal(mockedSlaveData.data.temp);
+    expect(slave.hum).to.equal(mockedSlaveData.data.hum);
 
     stubRead.restore();
     stubWrite.restore();
@@ -602,9 +725,10 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { desired } = data;
 
     assert.isTrue(body.success);
-    assert.isUndefined(data.desiredTemp);
+    assert.isUndefined(desired);
 
     stub.restore();
   });
@@ -616,9 +740,10 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { master } = data;
 
     assert.isTrue(body.success);
-    assert.isUndefined(data.heating);
+    assert.isUndefined(master.heating);
 
     stub.restore();
   });
@@ -630,9 +755,10 @@ describe('Status Route', () => {
     const response = await chai.request(expressApp).get('/v1/status');
     const { body } = response;
     const { data } = body;
+    const { master } = data;
 
     assert.isTrue(body.success);
-    assert.isUndefined(data.currentTemp);
+    assert.isUndefined(master.temp);
 
     stub.restore();
   });

--- a/test/routes/status.route.test.js
+++ b/test/routes/status.route.test.js
@@ -143,7 +143,6 @@ describe('Status Route', () => {
     const { slave } = data;
     const { mqtt } = data;
 
-    console.log(body);
     assert.isTrue(body.success);
 
     assert.isDefined(master);
@@ -162,7 +161,7 @@ describe('Status Route', () => {
 
     assert.isDefined(mqtt);
     expect(mqtt.updated).to.equal(1550586338221);
-    expect(mqtt.value).to.equal(12.5);
+    expect(mqtt.temp).to.equal(12.5);
   });
 
   it('should get status [with prio]', async () => {


### PR DESCRIPTION
Refactored status route response:

```
{
  "success": true,
  "data": {
    "master": {
      "heating": true,
      "temp": 21
    },
    "slave": {
      "temp": 12.5,
      "hum": 32
    },
    "mqtt": {
      "updated": 1550586338221,
      "temp": 12.5
    },
    "desired": {
      "temp": 25.4,
      "master": 100,
      "slave": 0
    }
  }
}
```